### PR TITLE
Fix issue #120 Remote notification listener does not occur. (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,19 @@ And then in your AppDelegate implementation, add the following:
   ...
   // Define UNUserNotificationCenter
   UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-  center.delegate = self;
-
-  return YES;
+  
+  // Set the delegate after we know that the user has given permission
+  [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+    if (settings.authorizationStatus == UNAuthorizationStatusAuthorized) {
+      [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert + UNAuthorizationOptionSound + UNAuthorizationOptionBadge)completionHandler:^(BOOL granted, NSError * _Nullable error) {
+               if (granted) {
+                 center.delegate = self;
+                }
+       }];
+    }
+  }];
+  [RNCPushNotificationIOS setADelegate: self];
+  ...
 }
 
 //Called when a notification is delivered to a foreground app.

--- a/ios/RNCPushNotificationIOS.h
+++ b/ios/RNCPushNotificationIOS.h
@@ -22,6 +22,7 @@ typedef void (^RNCRemoteNotificationCallback)(UIBackgroundFetchResult result);
 + (void)didReceiveLocalNotification:(UILocalNotification *)notification;
 + (void)didReceiveNotificationResponse:(UNNotificationResponse *)response API_AVAILABLE(ios(10.0));
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
++ (void)setADelegate:(id <UNUserNotificationCenterDelegate>)delegate;
 #endif
 
 @end

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -22,6 +22,8 @@ static NSString *const kRemoteNotificationRegistrationFailed = @"RemoteNotificat
 
 static NSString *const kErrorUnableToRequestPermissions = @"E_UNABLE_TO_REQUEST_PERMISSIONS";
 
+static id <UNUserNotificationCenterDelegate> delegate;
+
 #if !TARGET_OS_TV
 @implementation RCTConvert (NSCalendarUnit)
 
@@ -239,6 +241,11 @@ API_AVAILABLE(ios(10.0)) {
                                         userInfo:RCTFormatOpenedUNNotification(response.notification)];
 }
 
++ (void)setADelegate:(id <UNUserNotificationCenterDelegate>)adelegate
+{
+    delegate = adelegate;
+}
+
 - (void)handleLocalNotificationReceived:(NSNotification *)notification
 {
   [self sendEventWithName:@"localNotificationReceived" body:notification.userInfo];
@@ -265,6 +272,8 @@ API_AVAILABLE(ios(10.0)) {
 - (void)handleRemoteNotificationsRegistered:(NSNotification *)notification
 {
   [self sendEventWithName:@"remoteNotificationsRegistered" body:notification.userInfo];
+  UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+  center.delegate = delegate;
 }
 
 - (void)handleRemoteNotificationRegistrationError:(NSNotification *)notification


### PR DESCRIPTION
This solution makes sure that the delegate is set after the user has permission, without asking for permissions when the app is first started. The users unfortunately needs to edit their appDelegate.m file for this new change to work.

It might not be the prettiest solution, but it is simple and it works.