### PR TITLE
feat: include response actionIdentifier in event

### DIFF
--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -128,14 +128,16 @@ static NSDictionary *RCTFormatUNNotification(UNNotification *notification)
 }
 
 API_AVAILABLE(ios(10.0))
-static NSDictionary *RCTFormatOpenedUNNotification(UNNotification *notification)
+static NSDictionary *RCTFormatOpenedUNNotification(UNNotificationResponse *response)
 {
+  UNNotification* notification = response.notification;
   NSMutableDictionary *formattedNotification = [RCTFormatUNNotification(notification) mutableCopy];
   UNNotificationContent *content = notification.request.content;
     
   NSMutableDictionary *userInfo = [content.userInfo mutableCopy];
   userInfo[@"userInteraction"] = [NSNumber numberWithInt:1];
-  
+  userInfo[@"actionIdentifier"] = response.actionIdentifier;
+
   formattedNotification[@"userInfo"] = RCTNullIfNil(RCTJSONClean(userInfo));
     
   return formattedNotification;
@@ -236,7 +238,7 @@ RCT_EXPORT_MODULE()
 API_AVAILABLE(ios(10.0)) {
   [[NSNotificationCenter defaultCenter] postNotificationName:kLocalNotificationReceived
                                                       object:self
-                                        userInfo:RCTFormatOpenedUNNotification(response.notification)];
+                                        userInfo:RCTFormatOpenedUNNotification(response)];
 }
 
 - (void)handleLocalNotificationReceived:(NSNotification *)notification


### PR DESCRIPTION
### motivation

the current implementation of [didReceiveNotificationResponse](https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/1649501-usernotificationcenter?language=objc) which "Asks the delegate to process the user's response to a delivered notification." ignores the user response.

This fixes the issue, and user's action identifier will be present in `actionIdentifier` field in the JS event payload.