### PR TITLE
chore: Remove what appears to be unneeded, unused `handler` paramter …

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Valid events are:
 ### `removeEventListener()`
 
 ```jsx
-PushNotificationIOS.removeEventListener(type, handler);
+PushNotificationIOS.removeEventListener(type);
 ```
 
 Removes the event listener. Do this in `componentWillUnmount` to prevent memory leaks
@@ -408,7 +408,6 @@ Removes the event listener. Do this in `componentWillUnmount` to prevent memory 
 | Name    | Type     | Required | Description |
 | ------- | -------- | -------- | ----------- |
 | type    | string   | Yes      | Event type. |
-| handler | function | Yes      | Listener.   |
 
 ---
 

--- a/example/App.js
+++ b/example/App.js
@@ -54,18 +54,15 @@ export const App = () => {
     );
 
     return () => {
-      PushNotificationIOS.removeEventListener('register', onRegistered);
+      PushNotificationIOS.removeEventListener('register');
       PushNotificationIOS.removeEventListener(
-        'registrationError',
-        onRegistrationError,
+        'registrationError'
       );
       PushNotificationIOS.removeEventListener(
-        'notification',
-        onRemoteNotification,
+        'notification'
       );
       PushNotificationIOS.removeEventListener(
-        'localNotification',
-        onLocalNotification,
+        'localNotification'
       );
     };
   }, []);

--- a/index.d.ts
+++ b/index.d.ts
@@ -179,7 +179,7 @@ export interface PushNotificationIOSStatic {
    */
   FetchResult: FetchResult;
   /**
-   * Authorization status of notification settings 
+   * Authorization status of notification settings
    * For a list of possible values, see `PushNotificationIOS.AuthorizationStatus`.
    */
   AuthorizationStatus: AuthorizationStatus;
@@ -303,10 +303,6 @@ export interface PushNotificationIOSStatic {
    */
   removeEventListener(
     type: PushNotificationEventName,
-    handler:
-      | ((notification: PushNotification) => void)
-      | ((deviceToken: string) => void)
-      | ((error: {message: string; code: number; details: any}) => void),
   ): void;
 
   /**

--- a/js/index.js
+++ b/js/index.js
@@ -279,7 +279,6 @@ class PushNotificationIOS {
    */
   static removeEventListener(
     type: PushNotificationEventName,
-    handler: Function,
   ) {
     invariant(
       type === 'notification' ||


### PR DESCRIPTION
I know that it is a common paradigm to have a function pointer passed to a removeListener function - especially when that event can handle multiple listeners.

However, with push-notification-ios, the `handler` parameter to removeEventListener _appears_ to be unused and unnecessary. I also see no other reason (such as a naming pattern) that would require this and no comments either.

This apparently did not just trip me up as there are issues in the issue log related to it: https://github.com/react-native-push-notification-ios/push-notification-ios/issues/10

It would be good to either accept this pull request or provide more explanation in the documentation for why this parameter is needed.