### PR TITLE
feat: add removeAllPendingNotificationRequests method

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,13 @@ details is an object containing:
 
 ---
 
-### `cancelAllLocalNotifications()`
+### `remooveAllPendingNotificationRequests()`
 
 ```jsx
-PushNotificationIOS.cancelAllLocalNotifications();
+PushNotificationIOS.remooveAllPendingNotificationRequests();
 ```
 
-Cancels all scheduled localNotifications
+Removes all pending notification requests in the notification center.
 
 ---
 

--- a/example/App.js
+++ b/example/App.js
@@ -55,16 +55,11 @@ export const App = () => {
 
     return () => {
       PushNotificationIOS.removeEventListener('register');
-      PushNotificationIOS.removeEventListener(
-        'registrationError'
-      );
-      PushNotificationIOS.removeEventListener(
-        'notification'
-      );
-      PushNotificationIOS.removeEventListener(
-        'localNotification'
-      );
+      PushNotificationIOS.removeEventListener('registrationError');
+      PushNotificationIOS.removeEventListener('notification');
+      PushNotificationIOS.removeEventListener('localNotification');
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const sendNotification = () => {
@@ -87,7 +82,7 @@ export const App = () => {
       aps: {
         category: 'REACT_NATIVE',
         'content-available': 1,
-      }
+      },
     });
   };
 
@@ -102,8 +97,12 @@ export const App = () => {
   const scheduleLocalNotification = () => {
     PushNotificationIOS.scheduleLocalNotification({
       alertBody: 'Test Local Notification',
-      fireDate: new Date().toISOString(),
+      fireDate: new Date(new Date().valueOf() + 2000).toISOString(),
     });
+  };
+
+  const removeAllPendingNotificationRequests = () => {
+    PushNotificationIOS.removeAllPendingNotificationRequests();
   };
 
   const onRegistered = (deviceToken) => {
@@ -129,7 +128,7 @@ export const App = () => {
   };
 
   const onRemoteNotification = (notification) => {
-    const isClicked = notification.getData().userInteraction === 1
+    const isClicked = notification.getData().userInteraction === 1;
 
     const result = `
       Title:  ${notification.getTitle()};\n
@@ -148,7 +147,7 @@ export const App = () => {
         },
       ]);
     } else {
-       Alert.alert('Push Notification Received', result, [
+      Alert.alert('Push Notification Received', result, [
         {
           text: 'Dismiss',
           onPress: null,
@@ -158,7 +157,7 @@ export const App = () => {
   };
 
   const onLocalNotification = (notification) => {
-    const isClicked = notification.getData().userInteraction === 1
+    const isClicked = notification.getData().userInteraction === 1;
 
     Alert.alert(
       'Local Notification Received',
@@ -192,8 +191,14 @@ export const App = () => {
         onPress={scheduleLocalNotification}
         label="Schedule fake local notification"
       />
-
-      <Button onPress={sendSilentNotification} label="Send fake silent notification" />
+      <Button
+        onPress={removeAllPendingNotificationRequests}
+        label="Remove All Pending Notification Requests"
+      />
+      <Button
+        onPress={sendSilentNotification}
+        label="Send fake silent notification"
+      />
 
       <Button
         onPress={() => PushNotificationIOS.setApplicationIconBadgeNumber(42)}

--- a/index.d.ts
+++ b/index.d.ts
@@ -210,8 +210,14 @@ export interface PushNotificationIOSStatic {
 
   /**
    * Cancels all scheduled localNotifications
+   * @deprecated This method is deprecated in iOS 10 and will be removed from future release
    */
   cancelAllLocalNotifications(): void;
+
+  /**
+   * Removes all pending notifications
+   */
+  removeAllPendingNotificationRequests(): void;
 
   /**
    * Remove all delivered notifications from Notification Center.

--- a/index.d.ts
+++ b/index.d.ts
@@ -210,7 +210,8 @@ export interface PushNotificationIOSStatic {
 
   /**
    * Cancels all scheduled localNotifications
-   * @deprecated This method is deprecated in iOS 10 and will be removed from future release
+   * @deprecated use `removeAllPendingNotificationRequests` instead
+   * - This method is deprecated in iOS 10 and will be removed from future release
    */
   cancelAllLocalNotifications(): void;
 

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -391,6 +391,10 @@ RCT_EXPORT_METHOD(scheduleLocalNotification:(UILocalNotification *)notification)
   [RCTSharedApplication() scheduleLocalNotification:notification];
 }
 
+/**
+ * Method not Available in iOS11+
+ * TODO: This method will be removed in the next major version
+ */
 RCT_EXPORT_METHOD(cancelAllLocalNotifications)
 {
   [RCTSharedApplication() cancelAllLocalNotifications];

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -396,6 +396,14 @@ RCT_EXPORT_METHOD(cancelAllLocalNotifications)
   [RCTSharedApplication() cancelAllLocalNotifications];
 }
 
+RCT_EXPORT_METHOD(removeAllPendingNotificationRequests)
+{
+    if ([UNUserNotificationCenter class]) {
+      UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+      [center removeAllPendingNotificationRequests];
+    }
+}
+
 RCT_EXPORT_METHOD(cancelLocalNotifications:(NSDictionary<NSString *, id> *)userInfo)
 {
   for (UILocalNotification *notification in RCTSharedApplication().scheduledLocalNotifications) {

--- a/js/index.js
+++ b/js/index.js
@@ -102,7 +102,7 @@ class PushNotificationIOS {
 
   /**
    * Schedules the localNotification for immediate presentation.
-   * 
+   *
    * See https://reactnative.dev/docs/pushnotificationios.html#presentlocalnotification
    */
   static presentLocalNotification(details: Object) {

--- a/js/index.js
+++ b/js/index.js
@@ -102,7 +102,7 @@ class PushNotificationIOS {
 
   /**
    * Schedules the localNotification for immediate presentation.
-   *
+   * 
    * See https://reactnative.dev/docs/pushnotificationios.html#presentlocalnotification
    */
   static presentLocalNotification(details: Object) {
@@ -120,8 +120,8 @@ class PushNotificationIOS {
 
   /**
    * Cancels all scheduled localNotifications.
-   * @deprecated This method is deprecated in iOS 10 and will be removed from future release
-   * See https://reactnative.dev/docs/pushnotificationios.html#cancelalllocalnotifications
+   * @deprecated use `removeAllPendingNotificationRequests` instead
+   * - This method is deprecated in iOS 10 and will be removed from future release
    */
   static cancelAllLocalNotifications() {
     invariant(

--- a/js/index.js
+++ b/js/index.js
@@ -120,7 +120,7 @@ class PushNotificationIOS {
 
   /**
    * Cancels all scheduled localNotifications.
-   *
+   * @deprecated This method is deprecated in iOS 10 and will be removed from future release
    * See https://reactnative.dev/docs/pushnotificationios.html#cancelalllocalnotifications
    */
   static cancelAllLocalNotifications() {
@@ -129,6 +129,17 @@ class PushNotificationIOS {
       'PushNotificationManager is not available.',
     );
     RNCPushNotificationIOS.cancelAllLocalNotifications();
+  }
+
+  /**
+   * Removes all pending notifications
+   */
+  static removeAllPendingNotificationRequests() {
+    invariant(
+      RNCPushNotificationIOS,
+      'PushNotificationManager is not available.',
+    );
+    RNCPushNotificationIOS.removeAllPendingNotificationRequests();
   }
 
   /**


### PR DESCRIPTION
Fix #201 
Added `removeAllPendingNotificationRequests` method to replace the deprecated `cancelAllNotifications` method.

cancelAllNotifications method will be removed in the next major version of this package
