### PR TITLE
Feat/add notification request

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 React Native Push Notification API for iOS.
 
+| Notification              | With Action               | With TextInput Action     |
+| ------------------------- | ------------------------- | ------------------------- |
+| <img src="" width="320"/> | <img src="" width="320"/> | <img src="" width="320"/> |
+
 ## Getting started
 
 ### Install
@@ -116,14 +120,7 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
          withCompletionHandler:(void (^)(void))completionHandler
 {
   [RNCPushNotificationIOS didReceiveNotificationResponse:response];
-  completionHandler();
 }
-// IOS 4-10 Required for the localNotification event.
-- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
-{
- [RNCPushNotificationIOS didReceiveLocalNotification:notification];
-}
-
 ```
 
 And then in your AppDelegate implementation, add the following:
@@ -184,6 +181,57 @@ export const App = () => {
 };
 ```
 
+## How to perform different action based on user selected action.
+
+```js
+export const App = () => {
+  const [permissions, setPermissions] = useState({});
+
+  /**
+   * By calling this function, notification with category `userAction` will have action buttons
+   */
+  const setNotificationCategories = () => {
+    PushNotificationIOS.setNotificationCategories([
+      {
+        id: 'userAction',
+        actions: [
+          {id: 'open', title: 'Open', options: {foreground: true}},
+          {
+            id: 'ignore',
+            title: 'Desruptive',
+            options: {foreground: true, destructive: true},
+          },
+          {
+            id: 'text',
+            title: 'Text Input',
+            options: {foreground: true},
+            textInput: {buttonTitle: 'Send'},
+          },
+        ],
+      },
+    ]);
+  };
+
+  useEffect(() => {
+    PushNotificationIOS.addEventListener('notification', onRemoteNotification);
+  });
+
+  const onRemoteNotification = (notification) => {
+    const actionIdentifier = notification.getActionIdentifier();
+
+    if (actionIdentifier === 'open') {
+      // Perform action based on open action
+    }
+
+    if (actionIdentifier === 'text') {
+      // Text that of user input.
+      const userText = notification.getUserText();
+      // Perform action based on textinput action
+    }
+  };
+};
+```
+
 # Reference
 
 ## Methods
@@ -194,6 +242,7 @@ export const App = () => {
 PushNotificationIOS.presentLocalNotification(details);
 ```
 
+_Deprecated_ - use `addNotificationRequest` instead.
 Schedules the localNotification for immediate presentation.
 
 **Parameters:**
@@ -221,6 +270,7 @@ details is an object containing:
 PushNotificationIOS.scheduleLocalNotification(details);
 ```
 
+_Deprecated_ - use `addNotificationRequest` instead.
 Schedules the localNotification for future presentation.
 
 **Parameters:**
@@ -241,6 +291,71 @@ details is an object containing:
 - `userInfo` : An object containing additional notification data (optional).
 - `applicationIconBadgeNumber` The number to display as the app's icon badge. Setting the number to 0 removes the icon badge (optional).
 - `repeatInterval` : The interval to repeat as a string. Possible values: `minute`, `hour`, `day`, `week`, `month`, `year` (optional).
+
+---
+
+### `addNotificationRequest()`
+
+```jsx
+PushNotificationIOS.addNotificationRequest(request);
+```
+
+Sends notificationRequest to notification center at specified firedate.
+Fires immediately if firedate is not set.
+
+**Parameters:**
+
+| Name    | Type   | Required | Description |
+| ------- | ------ | -------- | ----------- |
+| request | object | Yes      | See below.  |
+
+request is an object containing:
+
+- `id`: Identifier of the notification. Required in order to be able to retrieve specific notification. (required)
+- `title`: A short description of the reason for the alert.
+- `subtitle`: A secondary description of the reason for the alert.
+- `body` : The message displayed in the notification alert.
+- `badge` The number to display as the app's icon badge. Setting the number to 0 removes the icon badge.
+- `fireDate` : The date and time when the system should deliver the notification.
+- `repeats` : Sets notification to repeat daily. Must be used with fireDate.
+- `sound` : The sound played when the notification is fired.
+- `category` : The category of this notification, required for actionable notifications.
+- `isSilent` : If true, the notification will appear without sound.
+- `userInfo` : An object containing additional notification data.
+
+---
+
+### `setNotificationCategories()`
+
+```jsx
+PushNotificationIOS.setNotificationCategories(categories);
+```
+
+Sets category for the notification center.
+Allows you to add specific actions for notification with specific category.
+
+**Parameters:**
+
+| Name       | Type     | Required | Description |
+| ---------- | -------- | -------- | ----------- |
+| categories | object[] | Yes      | See below.  |
+
+`category` is an object containing:
+
+- `id`: Identifier of the notification category. Notification with this category will have the specified actions. (required)
+- `actions`: An array of notification actions to be attached to the notification of category id.
+
+`action` is an object containing:
+
+- `id`: Identifier of Action. This value will be returned as actionIdentifier when notification is received.
+- `title`: Text to be shown on notification action button.
+- `options`: Options for notification action.
+  - `foreground`: If `true`, action will be displayed on notification.
+  - `destructive`: If `true`, action will be displayed as destructive notification.
+  - `authenticationRequired`: If `true`, action will only be displayed for authenticated user.
+- `textInput`: Option for textInput action. If textInput prop exists, then user action will automatically become a text input action. The text user inputs will be in the userText field of the received notification.
+  - `buttonTitle`: Text to be shown on button when user finishes text input. Default is "Send" or its equivalent word in user's language setting.
+  - `placeholder`: Placeholder for text input for text input action.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 React Native Push Notification API for iOS.
 
-| Notification              | With Action               | With TextInput Action     |
-| ------------------------- | ------------------------- | ------------------------- |
-| <img src="" width="320"/> | <img src="" width="320"/> | <img src="" width="320"/> |
+| Notification                                                                                                                  | With Action                                                                                                                   | With TextInput Action                                                                                                         |
+| ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| <img src="https://user-images.githubusercontent.com/6936373/97115527-77c6ee80-173a-11eb-8440-049590a25f31.jpeg" width="320"/> | <img src="https://user-images.githubusercontent.com/6936373/97115526-772e5800-173a-11eb-8b51-c5263bced07a.jpeg" width="320"/> | <img src="https://user-images.githubusercontent.com/6936373/97115522-74cbfe00-173a-11eb-9644-fc1d5e634d6b.jpeg" width="320"/> |
 
 ## Getting started
 

--- a/example/App.js
+++ b/example/App.js
@@ -113,6 +113,17 @@ export const App = () => {
     });
   };
 
+  const getPendingNotificationRequests = () => {
+    PushNotificationIOS.getPendingNotificationRequests((requests) => {
+      Alert.alert('Push Notification Received', JSON.stringify(requests), [
+        {
+          text: 'Dismiss',
+          onPress: null,
+        },
+      ]);
+    });
+  };
+
   const setNotificationCategories = async () => {
     PushNotificationIOS.setNotificationCategories([
       {
@@ -260,6 +271,10 @@ export const App = () => {
       <Button
         onPress={() => PushNotificationIOS.setApplicationIconBadgeNumber(0)}
         label="Clear app's icon badge"
+      />
+      <Button
+        onPress={getPendingNotificationRequests}
+        label="Get Pending Notification Requests"
       />
       <View>
         <Button onPress={showPermissions} label="Show enabled permissions" />

--- a/example/App.js
+++ b/example/App.js
@@ -101,6 +101,15 @@ export const App = () => {
     });
   };
 
+  const addNotificationRequest = () => {
+    PushNotificationIOS.addNotificationRequest({
+      id: 'test',
+      title: 'title',
+      subtitle: 'subtitle',
+      body: 'body',
+    });
+  };
+
   const removeAllPendingNotificationRequests = () => {
     PushNotificationIOS.removeAllPendingNotificationRequests();
   };
@@ -132,6 +141,7 @@ export const App = () => {
 
     const result = `
       Title:  ${notification.getTitle()};\n
+      Subtitle:  ${notification.getSubtitle()};\n
       Message: ${notification.getMessage()};\n
       badge: ${notification.getBadgeCount()};\n
       sound: ${notification.getSound()};\n
@@ -162,7 +172,8 @@ export const App = () => {
     Alert.alert(
       'Local Notification Received',
       `Alert title:  ${notification.getTitle()},
-      'Alert message:  ${notification.getMessage()},
+      Alert subtitle:  ${notification.getSubtitle()},
+      Alert message:  ${notification.getMessage()},
       Notification is clicked: ${String(isClicked)}.`,
       [
         {
@@ -192,6 +203,10 @@ export const App = () => {
         label="Schedule fake local notification"
       />
       <Button
+        onPress={addNotificationRequest}
+        label="Add Notification Request"
+      />
+      <Button
         onPress={removeAllPendingNotificationRequests}
         label="Remove All Pending Notification Requests"
       />
@@ -199,7 +214,6 @@ export const App = () => {
         onPress={sendSilentNotification}
         label="Send fake silent notification"
       />
-
       <Button
         onPress={() => PushNotificationIOS.setApplicationIconBadgeNumber(42)}
         label="Set app's icon badge to 42"

--- a/example/App.js
+++ b/example/App.js
@@ -131,6 +131,16 @@ export const App = () => {
         ],
       },
     ]);
+    Alert.alert(
+      'setNotificationCategories',
+      `Set notification category complete`,
+      [
+        {
+          text: 'Dismiss',
+          onPress: null,
+        },
+      ],
+    );
   };
 
   const removeAllPendingNotificationRequests = () => {

--- a/example/App.js
+++ b/example/App.js
@@ -66,12 +66,12 @@ export const App = () => {
     DeviceEventEmitter.emit('remoteNotificationReceived', {
       remote: true,
       aps: {
-        alert: 'Sample notification',
-        badge: '+1',
+        alert: {title: 'title', subtitle: 'subtitle', body: 'body'},
+        badge: 1,
         sound: 'default',
-        alertTitle: 'title',
         category: 'REACT_NATIVE',
         'content-available': 1,
+        'mutable-content': 1,
       },
     });
   };
@@ -107,7 +107,30 @@ export const App = () => {
       title: 'title',
       subtitle: 'subtitle',
       body: 'body',
+      category: 'test',
     });
+  };
+
+  const setNotificationCategories = async () => {
+    PushNotificationIOS.setNotificationCategories([
+      {
+        id: 'test',
+        actions: [
+          {id: 'reply', title: 'Reply', options: {foreground: true}},
+          {
+            id: 'ignore',
+            title: 'Desruptive',
+            options: {foreground: true, destructive: true},
+          },
+          {
+            id: 'text',
+            title: 'Text',
+            options: {foreground: true},
+            textInput: {buttonTitle: 'Send', placeholder: 'placeholder'},
+          },
+        ],
+      },
+    ]);
   };
 
   const removeAllPendingNotificationRequests = () => {
@@ -205,6 +228,10 @@ export const App = () => {
       <Button
         onPress={addNotificationRequest}
         label="Add Notification Request"
+      />
+      <Button
+        onPress={setNotificationCategories}
+        label="Set notification categories"
       />
       <Button
         onPress={removeAllPendingNotificationRequests}

--- a/example/App.js
+++ b/example/App.js
@@ -139,7 +139,7 @@ export const App = () => {
             id: 'text',
             title: 'Text',
             options: {foreground: true},
-            textInput: {buttonTitle: 'Send', placeholder: 'placeholder'},
+            textInput: {buttonTitle: 'Send'},
           },
         ],
       },

--- a/example/App.js
+++ b/example/App.js
@@ -220,6 +220,8 @@ export const App = () => {
       `Alert title:  ${notification.getTitle()},
       Alert subtitle:  ${notification.getSubtitle()},
       Alert message:  ${notification.getMessage()},
+      Action Id:  ${notification.getActionIdentifier()},
+      User Text:  ${notification.getUserText()},
       Notification is clicked: ${String(isClicked)}.`,
       [
         {

--- a/example/App.js
+++ b/example/App.js
@@ -108,6 +108,8 @@ export const App = () => {
       subtitle: 'subtitle',
       body: 'body',
       category: 'test',
+      fireDate: new Date(new Date().valueOf() + 2000),
+      repeats: true,
     });
   };
 

--- a/example/App.js
+++ b/example/App.js
@@ -129,7 +129,7 @@ export const App = () => {
       {
         id: 'test',
         actions: [
-          {id: 'reply', title: 'Reply', options: {foreground: true}},
+          {id: 'open', title: 'Open', options: {foreground: true}},
           {
             id: 'ignore',
             title: 'Desruptive',
@@ -137,7 +137,7 @@ export const App = () => {
           },
           {
             id: 'text',
-            title: 'Text',
+            title: 'Text Input',
             options: {foreground: true},
             textInput: {buttonTitle: 'Send'},
           },

--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -116,7 +116,6 @@ static void InitializeFlipper(UIApplication *application) {
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler {
   [RNCPushNotificationIOS didReceiveNotificationResponse:response];
-  completionHandler();
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {

--- a/example/ios/example/example.entitlements
+++ b/example/ios/example/example.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,11 +15,67 @@ export interface AuthorizationStatus {
   UNAuthorizationStatusProvisional: 3;
 }
 
+/**
+ * Alert Object that can be included in the aps `alert` object
+ */
+export type NotificationAlert = {
+  title?: string;
+  subtitle?: string;
+  body?: string;
+};
+
+/**
+ * Notification Category that can include specific actions
+ */
+export type NotificationCategory = {
+  id: string;
+  actions: NotificationAction[];
+};
+
+/**
+ * Notification Action that can be added to specific categories
+ */
+export type NotificationAction = {
+  /**
+   * Id of Action.
+   * This value will be returned as actionIdentifier when notification is received.
+   */
+  id: string;
+  /**
+   * Text to be shown on notification action button.
+   */
+  title: string;
+  /**
+   * Option for notification action.
+   */
+  options?: {
+    foreground?: boolean;
+    destructive?: boolean;
+    authenticationRequired?: boolean;
+  };
+  /**
+   * Option for textInput action.
+   * If textInput prop exists, then user action will automatically become a text input action.
+   * The text user inputs will be in the userText field of the received notification.
+   */
+  textInput?: {
+    /**
+     * Text to be shown on button when user finishes text input.
+     * Default is "Send" or its equivalent word in user's language setting.
+     */
+    buttonTitle?: string;
+    /**
+     * Placeholder for text input for text input action.
+     */
+    placeholder?: string;
+  };
+};
+
 export interface PushNotification {
   /**
    * An alias for `getAlert` to get the notification's main message string
    */
-  getMessage(): string | Record<string, any>;
+  getMessage(): string | NotificationAlert;
 
   /**
    * Gets the sound string from the `aps` object
@@ -34,7 +90,7 @@ export interface PushNotification {
   /**
    * Gets the notification's main message from the `aps` object
    */
-  getAlert(): string | Record<string, any>;
+  getAlert(): string | NotificationAlert;
 
   /**
    * Gets the notification's title from the `aps` object
@@ -57,12 +113,71 @@ export interface PushNotification {
   getData(): Record<string, any>;
 
   /**
+   * Get's the action id of the notification action user has taken.
+   */
+  getActionIdentifier(): string | undefined;
+
+  /**
+   * Gets the text user has inputed if user has taken the text action response.
+   */
+  getUserText(): string | undefined;
+
+  /**
    * iOS Only
    * Signifies remote notification handling is complete
    */
   finish(result: string): void;
 }
 
+export type NotificationRequest = {
+  /**
+   * identifier of the notification.
+   * Required in order to retrieve specific notification.
+   */
+  id: string;
+  /**
+   * A short description of the reason for the alert.
+   */
+  title?: string;
+  /**
+   * A secondary description of the reason for the alert.
+   */
+  subtitle?: string;
+  /**
+   * The message displayed in the notification alert.
+   */
+  body?: string;
+  /**
+   * The number to display as the app's icon badge.
+   */
+  badge?: number;
+  /**
+   * The sound to play when the notification is delivered.
+   */
+  sound?: string;
+  /**
+   * The date which notification triggers.
+   */
+  fireDate?: Date;
+  /**
+   * Sets notification to repeat daily.
+   * Must be used with fireDate.
+   */
+  repeats?: boolean;
+  /**
+   * Sets notification to be silent
+   */
+  isSilent?: boolean;
+  /**
+   * Optional data to be added to the notification
+   */
+  userInfo?: Record<string, any>;
+};
+
+/**
+ * @deprecated see `NotificationRequest`
+ * - This type will be removed in the next major version
+ */
 export interface PresentLocalNotificationDetails {
   /**
    * The "action" displayed beneath an actionable notification. Defaults to "view";
@@ -98,6 +213,10 @@ export interface PresentLocalNotificationDetails {
   userInfo?: Record<string, any>;
 }
 
+/**
+ * @deprecated see `NotificationRequest`
+ * - This type will be removed in the next major version
+ */
 export interface ScheduleLocalNotificationDetails {
   /**
    * The "action" displayed beneath an actionable notification. Defaults to "view";
@@ -145,8 +264,11 @@ export interface ScheduleLocalNotificationDetails {
 export type DeliveredNotification = {
   identifier: string;
   title: string;
+  subtitle: string;
   body: string;
   category?: string;
+  actionIdentifier?: string;
+  userText?: string;
   userInfo?: Record<string, any>;
   'thread-id'?: string;
 };
@@ -168,9 +290,6 @@ export type PushNotificationEventName =
 
 /**
  * Handle push notifications for your app, including permission handling and icon badge number.
- * @see https://reactnative.dev/docs/pushnotificationios.html#content
- *
- * //FIXME: BGR: The documentation seems completely off compared to the actual js implementation. I could never get the example to run
  */
 export interface PushNotificationIOSStatic {
   /**
@@ -184,6 +303,7 @@ export interface PushNotificationIOSStatic {
    */
   AuthorizationStatus: AuthorizationStatus;
   /**
+   * @deprecated use `addNotificationRequest`
    * Schedules the localNotification for immediate presentation.
    * details is an object containing:
    * alertBody : The message displayed in the notification alert.
@@ -196,6 +316,7 @@ export interface PushNotificationIOSStatic {
   presentLocalNotification(details: PresentLocalNotificationDetails): void;
 
   /**
+   * @deprecated use `addNotificationRequest`
    * Schedules the localNotification for future presentation.
    * details is an object containing:
    * fireDate : The date and time when the system should deliver the notification.
@@ -207,6 +328,12 @@ export interface PushNotificationIOSStatic {
    * applicationIconBadgeNumber (optional) : The number to display as the app's icon badge. Setting the number to 0 removes the icon badge.
    */
   scheduleLocalNotification(details: ScheduleLocalNotificationDetails): void;
+
+  /**
+   * Sends notificationRequest to notification center at specified firedate.
+   * Fires immediately if firedate is not set.
+   */
+  addNotificationRequest(request: NotificationRequest): void;
 
   /**
    * Cancels all scheduled localNotifications
@@ -254,16 +381,27 @@ export interface PushNotificationIOSStatic {
   getApplicationIconBadgeNumber(callback: (badge: number) => void): void;
 
   /**
-   * Cancel local notifications.
-   * Optionally restricts the set of canceled notifications to those notifications whose userInfo fields match the corresponding fields in the userInfo argument.
+   * @deprecated use `removeAllPendingNotificationRequests`
+   * - This method will be removed in the next major version
+   * - Cancel local notifications.
+   * - Optionally restricts the set of canceled notifications to those notifications whose userInfo fields match the corresponding fields in the userInfo argument.
    */
   cancelLocalNotifications(userInfo: Record<string, any>): void;
 
   /**
-   * Gets the local notifications that are currently scheduled.
+   * @deprecated use `getPendingNotificationRequests`
+   * - This method will be removed in the next major version
+   * - Gets the local notifications that are currently scheduled.
    */
   getScheduledLocalNotifications(
     callback: (notifications: ScheduleLocalNotificationDetails[]) => void,
+  ): void;
+
+  /**
+   * - Gets all pending notification requests that are currently scheduled.
+   */
+  getPendingNotificationRequests(
+    callback: (notifications: NotificationRequest[]) => void,
   ): void;
 
   /**
@@ -308,9 +446,7 @@ export interface PushNotificationIOSStatic {
    * Removes the event listener. Do this in `componentWillUnmount` to prevent
    * memory leaks
    */
-  removeEventListener(
-    type: PushNotificationEventName,
-  ): void;
+  removeEventListener(type: PushNotificationEventName): void;
 
   /**
    * Requests all notification permissions from iOS, prompting the user's
@@ -349,6 +485,12 @@ export interface PushNotificationIOSStatic {
    * object if the app was launched by a push notification, or `null` otherwise.
    */
   getInitialNotification(): Promise<PushNotification | null>;
+
+  /**
+   * Sets notification category to notification center.
+   * Used to set specific actions for notifications that contains specified category
+   */
+  setNotificationCategories(categories: NotificationCategory[]): void;
 }
 
 declare const PushNotificationIOS: PushNotificationIOSStatic;

--- a/index.d.ts
+++ b/index.d.ts
@@ -156,6 +156,10 @@ export type NotificationRequest = {
    */
   sound?: string;
   /**
+   * The category of this notification. Required for actionable notifications.
+   */
+  category?: string;
+  /**
    * The date which notification triggers.
    */
   fireDate?: Date;

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -148,13 +148,13 @@ RCT_ENUM_CONVERTER(UIBackgroundFetchResult, (@{
 {
     NSDictionary<NSString *, id> *details = [self NSDictionary:json];
     
+    NSString* identifier = [RCTConvert NSString:details[@"id"]];
     NSMutableArray* actions = [NSMutableArray new];
         for (NSDictionary* action in [RCTConvert NSArray:details[@"actions"]]) {
             [actions addObject:[RCTConvert UNNotificationAction:action]];
         }
     
-    
-    UNNotificationCategory* category = [UNNotificationCategory categoryWithIdentifier:@"category" actions:actions intentIdentifiers:@[] options:UNNotificationCategoryOptionNone];
+    UNNotificationCategory* category = [UNNotificationCategory categoryWithIdentifier:identifier actions:actions intentIdentifiers:@[] options:UNNotificationCategoryOptionNone];
     
     return category;
 }

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -41,9 +41,13 @@ RCT_ENUM_CONVERTER(NSCalendarUnit,
 
 @interface RNCPushNotificationIOS ()
 @property (nonatomic, strong) NSMutableDictionary *remoteNotificationCallbacks;
-@property (nonatomic, strong) UNUserNotificationCenter *center;
+
 @end
 
+/**
+ * Type deprecated in iOS 10.0
+ * TODO: This method will be removed in the next major version
+ */
 @implementation RCTConvert (UILocalNotification)
 
 + (UILocalNotification *)UILocalNotification:(id)json
@@ -83,8 +87,7 @@ RCT_ENUM_CONVERTER(UIBackgroundFetchResult, (@{
     
     BOOL isSilent = [RCTConvert BOOL:details[@"isSilent"]];
     NSString* identifier = [RCTConvert NSString:details[@"id"]];
-    NSCalendarUnit interval = [RCTConvert NSCalendarUnit:details[@"repeatInterval"]];
-    BOOL repeats = interval > 0;
+    
     
     UNMutableNotificationContent* content = [[UNMutableNotificationContent alloc] init];
     content.title= [RCTConvert NSString:details[@"title"]];
@@ -95,8 +98,15 @@ RCT_ENUM_CONVERTER(UIBackgroundFetchResult, (@{
     if (!isSilent) {
       content.sound = [RCTConvert NSString:details[@"sound"]] ? [UNNotificationSound soundNamed:[RCTConvert NSString:details[@"sound"]]] : [UNNotificationSound defaultSound];
     }
+
+    NSDate* fireDate = [RCTConvert NSDate:details[@"fireDate"]];
+    BOOL repeats = [RCTConvert BOOL:details[@"repeats"]];
+    NSDateComponents *triggerDate = fireDate ? [[NSCalendar currentCalendar] components:NSCalendarUnitYear +
+                                     NSCalendarUnitMonth + NSCalendarUnitDay +
+                                     NSCalendarUnitHour + NSCalendarUnitMinute +
+                                                NSCalendarUnitSecond + NSCalendarUnitTimeZone fromDate:fireDate] : nil;
     
-    UNTimeIntervalNotificationTrigger* trigger = repeats?  [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:interval repeats:repeats] : nil;
+    UNCalendarNotificationTrigger* trigger = triggerDate ? [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:triggerDate repeats:repeats] : nil;
 
     UNNotificationRequest* notification = [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:trigger];
     return notification;

--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -236,43 +236,45 @@ static NSDictionary *RCTFormatUNNotification(UNNotification *notification)
 
 static NSDictionary *RCTFormatUNNotificationRequest(UNNotificationRequest *request)
 {
-    NSMutableDictionary *formattedNotification = [NSMutableDictionary dictionary];
+    NSMutableDictionary *formattedRequest = [NSMutableDictionary dictionary];
     
-    formattedNotification[@"id"] = RCTNullIfNil(request.identifier);
+    formattedRequest[@"id"] = RCTNullIfNil(request.identifier);
     
     UNNotificationContent *content = request.content;
-    formattedNotification[@"title"] = RCTNullIfNil(content.title);
-    formattedNotification[@"subtitle"] = RCTNullIfNil(content.subtitle);
-    formattedNotification[@"body"] = RCTNullIfNil(content.body);
-    formattedNotification[@"category"] = RCTNullIfNil(content.categoryIdentifier);
-    formattedNotification[@"thread-id"] = RCTNullIfNil(content.threadIdentifier);
-    formattedNotification[@"userInfo"] = RCTNullIfNil(RCTJSONClean(content.userInfo));
+    formattedRequest[@"title"] = RCTNullIfNil(content.title);
+    formattedRequest[@"subtitle"] = RCTNullIfNil(content.subtitle);
+    formattedRequest[@"body"] = RCTNullIfNil(content.body);
+    formattedRequest[@"category"] = RCTNullIfNil(content.categoryIdentifier);
+    formattedRequest[@"thread-id"] = RCTNullIfNil(content.threadIdentifier);
+    formattedRequest[@"userInfo"] = RCTNullIfNil(RCTJSONClean(content.userInfo));
     
     if (request.trigger) {
         UNCalendarNotificationTrigger* trigger = (UNCalendarNotificationTrigger*)request.trigger;
         NSDateFormatter *formatter = [NSDateFormatter new];
         [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
         NSString *dateString = [formatter stringFromDate:trigger.nextTriggerDate];
-        formattedNotification[@"date"] = dateString;
+        formattedRequest[@"date"] = dateString;
     }
 
-    return formattedNotification;
+    return formattedRequest;
 }
 
 API_AVAILABLE(ios(10.0))
-static NSDictionary *RCTFormatOpenedUNNotification(UNNotificationResponse *response)
+static NSDictionary *RCTFormatOpenedUNNotification(UNTextInputNotificationResponse *response)
 {
   UNNotification* notification = response.notification;
-  NSMutableDictionary *formattedNotification = [RCTFormatUNNotification(notification) mutableCopy];
+  NSMutableDictionary *formattedResponse = [RCTFormatUNNotification(notification) mutableCopy];
   UNNotificationContent *content = notification.request.content;
     
   NSMutableDictionary *userInfo = [content.userInfo mutableCopy];
   userInfo[@"userInteraction"] = [NSNumber numberWithInt:1];
   userInfo[@"actionIdentifier"] = response.actionIdentifier;
 
-  formattedNotification[@"userInfo"] = RCTNullIfNil(RCTJSONClean(userInfo));
+  formattedResponse[@"userInfo"] = RCTNullIfNil(RCTJSONClean(userInfo));
+  formattedResponse[@"actionIdentifier"] = RCTNullIfNil(response.actionIdentifier);
+  formattedResponse[@"userText"] = RCTNullIfNil(response.userText);
     
-  return formattedNotification;
+  return formattedResponse;
 }
 
 #endif //TARGET_OS_TV / TARGET_OS_UIKITFORMAC

--- a/js/index.js
+++ b/js/index.js
@@ -12,7 +12,12 @@
 
 import {NativeEventEmitter, NativeModules} from 'react-native';
 import invariant from 'invariant';
-
+import {
+  NotificationAlert,
+  NotificationRequest,
+  NotificationCategory,
+  NotificationAction,
+} from './types';
 const {RNCPushNotificationIOS} = NativeModules;
 
 const PushNotificationEmitter = new NativeEventEmitter(RNCPushNotificationIOS);
@@ -24,49 +29,11 @@ const NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
 const NOTIF_REGISTRATION_ERROR_EVENT = 'remoteNotificationRegistrationError';
 const DEVICE_LOCAL_NOTIF_EVENT = 'localNotificationReceived';
 
-export type NotificationRequest = {
-  /**
-   * identifier of the notification.
-   * Required in order to retrieve specific notification.
-   */
-  id: string,
-  /**
-   * A short description of the reason for the alert.
-   */
-  title?: string,
-  /**
-   * A secondary description of the reason for the alert.
-   */
-  subtitle?: string,
-  /**
-   * The message displayed in the notification alert.
-   */
-  body?: string,
-  /**
-   * The number to display as the app's icon badge.
-   */
-  badge?: number,
-  /**
-   * The sound to play when the notification is delivered.
-   */
-  sound?: string,
-  /**
-   * The date which notification triggers.
-   */
-  fireDate?: Date,
-  /**
-   * Sets notification to repeat daily.
-   * Must be used with fireDate.
-   */
-  repeats?: boolean,
-  /**
-   * Sets notification to be silent
-   */
-  isSilent?: boolean,
-  /**
-   * Optional data to be added to the notification
-   */
-  userInfo?: Object,
+export {
+  NotificationAlert,
+  NotificationRequest,
+  NotificationCategory,
+  NotificationAction,
 };
 
 export type ContentAvailable = 1 | null | void;
@@ -111,31 +78,6 @@ export type PushNotificationEventName = $Keys<{
   registrationError: string,
 }>;
 
-type Alert = {
-  title?: string,
-  subtitle?: string,
-  body?: string,
-};
-
-type NotificationCategory = {
-  id: string,
-  actions: NotificationAction[],
-};
-
-type NotificationAction = {
-  id: string,
-  title: string,
-  options?: {
-    foreground?: boolean,
-    destructive?: boolean,
-    authenticationRequired?: boolean,
-  },
-  textInput?: {
-    buttonTitle?: string,
-    placeholder?: string,
-  },
-};
-
 /**
  *
  * Handle push notifications for your app, including permission handling and
@@ -145,7 +87,7 @@ type NotificationAction = {
  */
 class PushNotificationIOS {
   _data: Object;
-  _alert: string | Alert;
+  _alert: string | NotificationAlert;
   _title: string;
   _subtitle: string;
   _sound: string;
@@ -196,8 +138,8 @@ class PushNotificationIOS {
   }
 
   /**
-   * Sends notificationRequest to notification center.
-   * Fires immedietely if firedate or repeatInterval is not set.
+   * Sends notificationRequest to notification center at specified firedate.
+   * Fires immediately if firedate is not set.
    */
   static addNotificationRequest(request: NotificationRequest) {
     const handledRequest =
@@ -335,7 +277,9 @@ class PushNotificationIOS {
   /**
    * Gets the pending local notification requests.
    */
-  static getPendingNotificationRequests(callback: (requests: any[]) => void) {
+  static getPendingNotificationRequests(
+    callback: (requests: NotificationRequest[]) => void,
+  ) {
     invariant(
       RNCPushNotificationIOS,
       'PushNotificationManager is not available.',

--- a/js/index.js
+++ b/js/index.js
@@ -153,6 +153,14 @@ class PushNotificationIOS {
   _contentAvailable: ContentAvailable;
   _badgeCount: number;
   _notificationId: string;
+  /**
+   * The id of action the user has taken taken.
+   */
+  _actionIdentifier: ?string;
+  /**
+   * The text user has input if user responded with a text action.
+   */
+  _userText: ?string;
   _isRemote: boolean;
   _remoteNotificationCompleteCallbackCalled: boolean;
   _threadID: string;
@@ -500,11 +508,14 @@ class PushNotificationIOS {
       this._notificationId = nativeNotif.notificationId;
     }
 
+    this._actionIdentifier = nativeNotif.actionIdentifier;
+    this._userText = nativeNotif.userText;
     if (nativeNotif.remote) {
       // Extract data from Apple's `aps` dict as defined:
       // https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html
       Object.keys(nativeNotif).forEach((notifKey) => {
         const notifVal = nativeNotif[notifKey];
+
         if (notifKey === 'aps') {
           this._alert = notifVal.alert;
           this._title = notifVal?.alertTitle;
@@ -651,6 +662,20 @@ class PushNotificationIOS {
    */
   getThreadID(): ?string {
     return this._threadID;
+  }
+
+  /**
+   * Get's the action id of the notification action user has taken.
+   */
+  getActionIdentifier(): ?string {
+    return this._actionIdentifier;
+  }
+
+  /**
+   * Gets the text user has inputed if user has taken the text action response.
+   */
+  getUserText(): ?string {
+    return this._userText;
   }
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -56,6 +56,7 @@ export type NotificationRequest = {
   fireDate?: Date,
   /**
    * Sets notification to repeat daily.
+   * Must be used with fireDate.
    */
   repeats?: boolean,
   /**
@@ -313,8 +314,7 @@ class PushNotificationIOS {
 
   /**
    * Gets the local notifications that are currently scheduled.
-   *
-   * See https://reactnative.dev/docs/pushnotificationios.html#getscheduledlocalnotifications
+   * @deprecated - use `getPendingNotificationRequests`
    */
   static getScheduledLocalNotifications(callback: Function) {
     invariant(
@@ -322,6 +322,17 @@ class PushNotificationIOS {
       'PushNotificationManager is not available.',
     );
     RNCPushNotificationIOS.getScheduledLocalNotifications(callback);
+  }
+
+  /**
+   * Gets the pending local notification requests.
+   */
+  static getPendingNotificationRequests(callback: (requests: any[]) => void) {
+    invariant(
+      RNCPushNotificationIOS,
+      'PushNotificationManager is not available.',
+    );
+    RNCPushNotificationIOS.getPendingNotificationRequests(callback);
   }
 
   /**

--- a/js/index.js
+++ b/js/index.js
@@ -24,14 +24,6 @@ const NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
 const NOTIF_REGISTRATION_ERROR_EVENT = 'remoteNotificationRegistrationError';
 const DEVICE_LOCAL_NOTIF_EVENT = 'localNotificationReceived';
 
-export type RepeatInterval =
-  | 'year'
-  | 'hour'
-  | 'month'
-  | 'week'
-  | 'day'
-  | 'minute';
-
 export type NotificationRequest = {
   /**
    * identifier of the notification.
@@ -58,11 +50,14 @@ export type NotificationRequest = {
    * The sound to play when the notification is delivered.
    */
   sound?: string,
-
   /**
-   * The time that must elapse from the current time before the trigger fires.
+   * The date which notification triggers.
    */
-  repeatInterval?: RepeatInterval,
+  fireDate?: Date,
+  /**
+   * Sets notification to repeat daily.
+   */
+  repeats?: boolean,
   /**
    * Sets notification to be silent
    */
@@ -196,7 +191,12 @@ class PushNotificationIOS {
    * Fires immedietely if firedate or repeatInterval is not set.
    */
   static addNotificationRequest(request: NotificationRequest) {
-    RNCPushNotificationIOS.addNotificationRequest(request);
+    const handledRequest =
+      request.fireDate instanceof Date
+        ? {...request, fireDate: request.fireDate.toISOString()}
+        : request;
+
+    RNCPushNotificationIOS.addNotificationRequest(handledRequest);
   }
 
   /**

--- a/js/index.js
+++ b/js/index.js
@@ -60,14 +60,17 @@ export type NotificationRequest = {
   sound?: string,
 
   /**
-   * repeat interval
+   * The time that must elapse from the current time before the trigger fires.
    */
   repeatInterval?: RepeatInterval,
   /**
-   * isSilent
-   * sets notification to be silent
+   * Sets notification to be silent
    */
   isSilent?: boolean,
+  /**
+   * Optional data to be added to the notification
+   */
+  userInfo?: Object,
 };
 
 export type ContentAvailable = 1 | null | void;
@@ -112,6 +115,31 @@ export type PushNotificationEventName = $Keys<{
   registrationError: string,
 }>;
 
+type Alert = {
+  title?: string,
+  subtitle?: string,
+  body?: string,
+};
+
+type NotificationCategory = {
+  id: string,
+  actions: NotificationAction[],
+};
+
+type NotificationAction = {
+  id: string,
+  title: string,
+  options?: {
+    foreground?: boolean,
+    destructive?: boolean,
+    authenticationRequired?: boolean,
+  },
+  textInput?: {
+    buttonTitle?: string,
+    placeholder?: string,
+  },
+};
+
 /**
  *
  * Handle push notifications for your app, including permission handling and
@@ -121,7 +149,7 @@ export type PushNotificationEventName = $Keys<{
  */
 class PushNotificationIOS {
   _data: Object;
-  _alert: string | Object;
+  _alert: string | Alert;
   _title: string;
   _subtitle: string;
   _sound: string;
@@ -164,10 +192,19 @@ class PushNotificationIOS {
   }
 
   /**
-   * addNotificationRequest
+   * Sends notificationRequest to notification center.
+   * Fires immedietely if firedate or repeatInterval is not set.
    */
   static addNotificationRequest(request: NotificationRequest) {
     RNCPushNotificationIOS.addNotificationRequest(request);
+  }
+
+  /**
+   * Sets notification category to notification center.
+   * Used to set specific actions for notifications that contains specified category
+   */
+  static setNotificationCategories(categories: NotificationCategory[]) {
+    RNCPushNotificationIOS.setNotificationCategories(categories);
   }
 
   /**
@@ -514,7 +551,9 @@ class PushNotificationIOS {
    * An alias for `getAlert` to get the notification's main message string
    */
   getMessage(): ?string | ?Object {
-    // alias because "alert" is an ambiguous name
+    if (typeof this._alert === 'object') {
+      return this._alert?.body;
+    }
     return this._alert;
   }
 
@@ -550,6 +589,9 @@ class PushNotificationIOS {
    *
    */
   getTitle(): ?string | ?Object {
+    if (typeof this._alert === 'object') {
+      return this._alert?.title;
+    }
     return this._title;
   }
 
@@ -558,6 +600,9 @@ class PushNotificationIOS {
    *
    */
   getSubtitle(): ?string | ?Object {
+    if (typeof this._alert === 'object') {
+      return this._alert?.subtitle;
+    }
     return this._subtitle;
   }
 

--- a/js/index.js
+++ b/js/index.js
@@ -24,6 +24,52 @@ const NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
 const NOTIF_REGISTRATION_ERROR_EVENT = 'remoteNotificationRegistrationError';
 const DEVICE_LOCAL_NOTIF_EVENT = 'localNotificationReceived';
 
+export type RepeatInterval =
+  | 'year'
+  | 'hour'
+  | 'month'
+  | 'week'
+  | 'day'
+  | 'minute';
+
+export type NotificationRequest = {
+  /**
+   * identifier of the notification.
+   * Required in order to retrieve specific notification.
+   */
+  id: string,
+  /**
+   * A short description of the reason for the alert.
+   */
+  title?: string,
+  /**
+   * A secondary description of the reason for the alert.
+   */
+  subtitle?: string,
+  /**
+   * The message displayed in the notification alert.
+   */
+  body?: string,
+  /**
+   * The number to display as the app's icon badge.
+   */
+  badge?: number,
+  /**
+   * The sound to play when the notification is delivered.
+   */
+  sound?: string,
+
+  /**
+   * repeat interval
+   */
+  repeatInterval?: RepeatInterval,
+  /**
+   * isSilent
+   * sets notification to be silent
+   */
+  isSilent?: boolean,
+};
+
 export type ContentAvailable = 1 | null | void;
 
 export type FetchResult = {
@@ -77,6 +123,7 @@ class PushNotificationIOS {
   _data: Object;
   _alert: string | Object;
   _title: string;
+  _subtitle: string;
   _sound: string;
   _category: string;
   _contentAvailable: ContentAvailable;
@@ -102,8 +149,7 @@ class PushNotificationIOS {
 
   /**
    * Schedules the localNotification for immediate presentation.
-   *
-   * See https://reactnative.dev/docs/pushnotificationios.html#presentlocalnotification
+   * @deprecated use `addNotificationRequest` instead
    */
   static presentLocalNotification(details: Object) {
     RNCPushNotificationIOS.presentLocalNotification(details);
@@ -111,11 +157,17 @@ class PushNotificationIOS {
 
   /**
    * Schedules the localNotification for future presentation.
-   *
-   * See https://reactnative.dev/docs/pushnotificationios.html#schedulelocalnotification
+   * @deprecated use `addNotificationRequest` instead
    */
   static scheduleLocalNotification(details: Object) {
     RNCPushNotificationIOS.scheduleLocalNotification(details);
+  }
+
+  /**
+   * addNotificationRequest
+   */
+  static addNotificationRequest(request: NotificationRequest) {
+    RNCPushNotificationIOS.addNotificationRequest(request);
   }
 
   /**
@@ -408,6 +460,7 @@ class PushNotificationIOS {
         if (notifKey === 'aps') {
           this._alert = notifVal.alert;
           this._title = notifVal?.alertTitle;
+          this._subtitle = notifVal?.subtitle;
           this._sound = notifVal.sound;
           this._badgeCount = notifVal.badge;
           this._category = notifVal.category;
@@ -424,6 +477,7 @@ class PushNotificationIOS {
       this._sound = nativeNotif.soundName;
       this._alert = nativeNotif.body;
       this._title = nativeNotif?.title;
+      this._subtitle = nativeNotif?.subtitle;
       this._data = nativeNotif.userInfo;
       this._category = nativeNotif.category;
       this._fireDate = nativeNotif.fireDate;
@@ -497,6 +551,14 @@ class PushNotificationIOS {
    */
   getTitle(): ?string | ?Object {
     return this._title;
+  }
+
+  /**
+   * Gets the notification's subtitle from the `aps` object
+   *
+   */
+  getSubtitle(): ?string | ?Object {
+    return this._subtitle;
   }
 
   /**

--- a/js/types.js
+++ b/js/types.js
@@ -1,0 +1,100 @@
+export type NotificationRequest = {
+  /**
+   * identifier of the notification.
+   * Required in order to retrieve specific notification.
+   */
+  id: string,
+  /**
+   * A short description of the reason for the alert.
+   */
+  title?: string,
+  /**
+   * A secondary description of the reason for the alert.
+   */
+  subtitle?: string,
+  /**
+   * The message displayed in the notification alert.
+   */
+  body?: string,
+  /**
+   * The number to display as the app's icon badge.
+   */
+  badge?: number,
+  /**
+   * The sound to play when the notification is delivered.
+   */
+  sound?: string,
+  /**
+   * The date which notification triggers.
+   */
+  fireDate?: Date,
+  /**
+   * Sets notification to repeat daily.
+   * Must be used with fireDate.
+   */
+  repeats?: boolean,
+  /**
+   * Sets notification to be silent
+   */
+  isSilent?: boolean,
+  /**
+   * Optional data to be added to the notification
+   */
+  userInfo?: Object,
+};
+
+/**
+ * Alert Object that can be included in the aps `alert` object
+ */
+export type NotificationAlert = {
+  title?: string,
+  subtitle?: string,
+  body?: string,
+};
+
+/**
+ * Notification Category that can include specific actions
+ */
+export type NotificationCategory = {
+  id: string,
+  actions: NotificationAction[],
+};
+
+/**
+ * Notification Action that can be added to specific categories
+ */
+export type NotificationAction = {
+  /**
+   * Id of Action.
+   * This value will be returned as actionIdentifier when notification is received.
+   */
+  id: string,
+  /**
+   * Text to be shown on notification action button.
+   */
+  title: string,
+  /**
+   * Option for notification action.
+   */
+  options?: {
+    foreground?: boolean,
+    destructive?: boolean,
+    authenticationRequired?: boolean,
+  },
+  /**
+   * Option for textInput action.
+   * If textInput prop exists, then user action will automatically become a text input action.
+   * The text user inputs will be in the userText field of the received notification.
+   */
+  textInput?: {
+    /**
+     * Text to be shown on button when user finishes text input.
+     * Default is "Send" or its equivalent word in user's language setting.
+     */
+    buttonTitle?: string,
+    /**
+     * Placeholder for text input for text input action.
+     */
+    placeholder?: string,
+  },
+};

--- a/js/types.js
+++ b/js/types.js
@@ -25,6 +25,10 @@ export type NotificationRequest = {
    */
   sound?: string,
   /**
+   * The category of this notification. Required for actionable notifications.
+   */
+  category?: string,
+  /**
    * The date which notification triggers.
    */
   fireDate?: Date,
@@ -56,6 +60,10 @@ export type NotificationAlert = {
  * Notification Category that can include specific actions
  */
 export type NotificationCategory = {
+  /**
+   * Identifier of the notification category.
+   * Notification with this category will have the specified actions.
+   */
   id: string,
   actions: NotificationAction[],
 };
@@ -65,7 +73,7 @@ export type NotificationCategory = {
  */
 export type NotificationAction = {
   /**
-   * Id of Action.
+   * Identifier of Action.
    * This value will be returned as actionIdentifier when notification is received.
    */
   id: string,


### PR DESCRIPTION
#201 
adds `addNotificationRequest` method that will deprecate
`presentNotification` and `scheduleNotification` method

Also added `setNotificationCategories` which will allow notifications with multiple action buttons and text input actions

uses UNNotificationRequest, because UILocalNotification is deprecated since iOS10