### PR TITLE
docs: remove pre iOS10 information from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,6 @@ At the top of the file:
 Then, add the following lines:
 
 ```objective-c
-// Required to register for notifications
-- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
-{
- [RNCPushNotificationIOS didRegisterUserNotificationSettings:notificationSettings];
-}
 // Required for the register event.
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
@@ -110,7 +105,7 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 {
  [RNCPushNotificationIOS didFailToRegisterForRemoteNotificationsWithError:error];
 }
-// IOS 10+ Required for localNotification event
+// Required for localNotification event
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
 didReceiveNotificationResponse:(UNNotificationResponse *)response
          withCompletionHandler:(void (^)(void))completionHandler

--- a/example/App.js
+++ b/example/App.js
@@ -55,15 +55,9 @@ export const App = () => {
 
     return () => {
       PushNotificationIOS.removeEventListener('register');
-      PushNotificationIOS.removeEventListener(
-        'registrationError'
-      );
-      PushNotificationIOS.removeEventListener(
-        'notification'
-      );
-      PushNotificationIOS.removeEventListener(
-        'localNotification'
-      );
+      PushNotificationIOS.removeEventListener('registrationError');
+      PushNotificationIOS.removeEventListener('notification');
+      PushNotificationIOS.removeEventListener('localNotification');
     };
   }, []);
 
@@ -87,7 +81,7 @@ export const App = () => {
       aps: {
         category: 'REACT_NATIVE',
         'content-available': 1,
-      }
+      },
     });
   };
 
@@ -129,7 +123,7 @@ export const App = () => {
   };
 
   const onRemoteNotification = (notification) => {
-    const isClicked = notification.getData().userInteraction === 1
+    const isClicked = notification.getData().userInteraction === 1;
 
     const result = `
       Title:  ${notification.getTitle()};\n
@@ -148,7 +142,7 @@ export const App = () => {
         },
       ]);
     } else {
-       Alert.alert('Push Notification Received', result, [
+      Alert.alert('Push Notification Received', result, [
         {
           text: 'Dismiss',
           onPress: null,
@@ -158,8 +152,7 @@ export const App = () => {
   };
 
   const onLocalNotification = (notification) => {
-    const isClicked = notification.getData().userInteraction === 1
-
+    const isClicked = notification.getData().userInteraction === 1;
     Alert.alert(
       'Local Notification Received',
       `Alert title:  ${notification.getTitle()},
@@ -193,7 +186,10 @@ export const App = () => {
         label="Schedule fake local notification"
       />
 
-      <Button onPress={sendSilentNotification} label="Send fake silent notification" />
+      <Button
+        onPress={sendSilentNotification}
+        label="Send fake silent notification"
+      />
 
       <Button
         onPress={() => PushNotificationIOS.setApplicationIconBadgeNumber(42)}

--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -78,13 +78,6 @@ static void InitializeFlipper(UIApplication *application) {
                     UNAuthorizationOptionBadge);
 }
 
-// Required to register for notifications
-- (void)application:(UIApplication *)application
-    didRegisterUserNotificationSettings:
-        (UIUserNotificationSettings *)notificationSettings {
-  [RNCPushNotificationIOS
-      didRegisterUserNotificationSettings:notificationSettings];
-}
 // Required for the register event.
 - (void)application:(UIApplication *)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
@@ -106,12 +99,7 @@ static void InitializeFlipper(UIApplication *application) {
   [RNCPushNotificationIOS
       didFailToRegisterForRemoteNotificationsWithError:error];
 }
-// Required for the localNotification event.
-- (void)application:(UIApplication *)application
-    didReceiveLocalNotification:(UILocalNotification *)notification {
-  [RNCPushNotificationIOS didReceiveLocalNotification:notification];
-}
-// IOS 10+ Required for local notification tapped event
+// Required for local notification tapped event
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler {


### PR DESCRIPTION
Since the package only supports iOS10+, I've removed instructions for pre iOS10 devices