### PR TITLE
Set userInteraction for initialLocalNotification

### DIFF
--- a/ios/RNCPushNotificationIOS.m
+++ b/ios/RNCPushNotificationIOS.m
@@ -630,6 +630,9 @@ RCT_EXPORT_METHOD(getInitialNotification:(RCTPromiseResolveBlock)resolve
     initialNotification[@"remote"] = @YES;
     resolve(initialNotification);
   } else if (initialLocalNotification) {
+    NSMutableDictionary *userInfo = [[initialLocalNotification userInfo] mutableCopy];
+    userInfo[@"userInteraction"] = [NSNumber numberWithInt:1];
+    [initialLocalNotification setUserInfo:userInfo];
     resolve(RCTFormatLocalNotification(initialLocalNotification));
   } else {
     resolve((id)kCFNull);


### PR DESCRIPTION
Previously it was correctly set for "remove" notifications, but was not set for local ones, and this way "initialnotification" were never treated as "opened by user".
Initial fix was in #220 which broke compilation.