### PR TITLE
doc: remove irritating tripple dots from install instructions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ And then in your AppDelegate implementation, add the following:
 ```objective-c
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  ...
   // Define UNUserNotificationCenter
   UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
   center.delegate = self;


### PR DESCRIPTION
I am probably not the first one to stumble over that when copy&paste the code into the project